### PR TITLE
Update DA Preview script

### DIFF
--- a/events/scripts/scripts.js
+++ b/events/scripts/scripts.js
@@ -254,7 +254,10 @@ async function loadPage() {
 (async function loadDa() {
   if (!new URL(window.location.href).searchParams.get('dapreview')) return;
   // eslint-disable-next-line import/no-unresolved
-  import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(loadPage));
+  import('https://da.live/scripts/dapreview.js').then(({ default: daPreview }) => daPreview(async () => {
+    processAutoBlockLinks(document);
+    await loadPage();
+  }));
 }());
 
 (async function init() {


### PR DESCRIPTION
In DA Preview, the page body gets replaced on each editor update, which reintroduced the raw Schedule Maker link (...schedule-maker?schedule=<base64>).
That link normally gets converted into a chrono-box, but this conversion wasn’t being rerun during DA preview refreshes, so the base64 link could show instead of the rendered fragment.

Fix: we rerun processAutoBlockLinks(document) inside loadPage() only when dapreview is present, before loadArea().

Result: preview updates now consistently convert Schedule Maker links back into chrono-box, and live/prod behavior is unchanged.