### PR TITLE
MWPW-191602: Disable geo-routing modal for French sites

### DIFF
--- a/404.html
+++ b/404.html
@@ -9,7 +9,7 @@
     <link rel="icon" href="data:,">
     <script>
       const path = window.location.pathname.toLowerCase();
-      if (/^\/([a-z]{2}_fr|fr)\//.test(path)) {
+      if (/^\/([a-z]{2}_fr)\//.test(path)) {
         const meta = document.createElement('meta');
         meta.setAttribute('name', 'georouting');
         meta.setAttribute('content', 'off');

--- a/404.html
+++ b/404.html
@@ -7,6 +7,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <script src="/events/scripts/scripts.js" type="module"></script>
     <link rel="icon" href="data:,">
+    <script>
+      const path = window.location.pathname.toLowerCase();
+      if (/^\/([a-z]{2}_fr|fr)\//.test(path)) {
+        const meta = document.createElement('meta');
+        meta.setAttribute('name', 'georouting');
+        meta.setAttribute('content', 'off');
+        document.head.append(meta);
+      }
+    </script>
     </head>
   <body>
     <header></header>


### PR DESCRIPTION
* Disables Geo-routing modal on the 404 pages for french sites -> lu_fr, ch_fr, be_fr, ca_fr.
* Continues to show Geo-routing modal for the other non-french sites
* This setup is temporary for Lingo Phase 2, 5/20 release. It will eventually be disabled site-wide (some time later this year), upon which the conditional site checks to inject the meta tag can be removed.

Resolves: [MWPW-191602](https://jira.corp.adobe.com/browse/MWPW-191602)

**Test URLs:**
- Before: https://main--da-events--adobecom.aem.live/lu_fr/events/lalaland.html?martech=off
- After: https://mwpw-191602--da-events--adobecom.aem.live/lu_fr/events/lalaland.html?martech=off
