### PR TITLE
[MWPW-195082] Fixed typo for window reload

### DIFF
--- a/events/scripts/scripts.js
+++ b/events/scripts/scripts.js
@@ -205,7 +205,7 @@ const CONFIG = {
     enableGuestBotDetection: false,
     api_parameters: { check_token: { guest_allowed: true } },
     onTokenExpired: () => {
-      window.locaton.reload();
+      window.location.reload();
     },
   },
   signInContext: getSusiOptions(),


### PR DESCRIPTION
 ### Summary
  
  - Fix typo in scripts.js: window.locaton.reload() → window.location.reload()

  The misspelling caused a silent TypeError on IMS token expiry — window.locaton is undefined, so .reload() would throw instead of refreshing the page. This means expired
  sessions were never recovered via page reload.

  ### Test Plan

  - Manual: Sign in to an event page, let the IMS token expire (or simulate expiry by calling window.adobeIMS.signOut() then triggering onTokenExpired), and confirm the page
  reloads instead of throwing a console error
  - Smoke: Load an event page on stage with a valid IMS session and verify normal login/logout flow is unaffected
  - npm run lint passes (no new lint errors)
  - npm test passes

Resolves: [MWPW-195082](https://jira.corp.adobe.com/browse/MWPW-195082)

Test URLs:
- Before: https://dev--da-events--adobecom.aem.live/drafts/
- After: https://MWPW-195082--da-events--adobecom.aem.live/drafts/

To test the feature, please load up the branch locally and run it against your local ESP and ESL server.
For more information on how to set up ESL and ESP locally, please refer to: [FE Dev Wiki](https://wiki.corp.adobe.com/display/adobedotcom/Events+Milo+FE+Dev+Wiki#EventsMiloFEDevWiki-Localdevelopmentsetup)
