### PR TITLE
T3.26-20 Release

### DIFF
--- a/.claude/commands/open-pr.md
+++ b/.claude/commands/open-pr.md
@@ -1,0 +1,41 @@
+Open a pull request from the current feature branch to the `stage` branch on GitHub (adobecom/da-events).
+
+## Steps
+
+1. Run `git branch --show-current` to get the current branch name. If already on `stage`, `dev`, or `main`, stop and tell the user to switch to a feature branch first.
+
+2. Collect the following details. The user may pass them as `$ARGUMENTS` in the format:
+   `ticket: MWPW-XXXXX | summary: ... | test plan: ...`
+   Parse them if present. For any that are missing or empty, ask the user before proceeding. Do NOT skip this step — all three are required.
+
+   - **Ticket** — e.g. `MWPW-12345`. If the branch name contains a ticket pattern like `MWPW-\d+`, pre-fill it and confirm with the user.
+   - **Summary** — 2–4 sentences: what changed and why.
+   - **Test plan** — bullet list of steps a reviewer should follow to verify the change works, including any relevant URLs or edge cases.
+
+3. Check whether the branch has an upstream tracking remote. If not, push it with `git push -u origin <branch>`.
+
+4. Use the `gh` CLI to create the PR:
+   - **Base branch**: `stage`
+   - **Title**: `<ticket>: <one-line summary>` (keep under 70 chars)
+   - **Body**: formatted as shown below
+
+   ```
+   gh pr create \
+     --base stage \
+     --title "<ticket>: <short title>" \
+     --body "$(cat <<'EOF'
+   ## Ticket
+   [<ticket>](https://jira.corp.adobe.com/browse/<ticket>)
+
+   ## Summary
+   <summary>
+
+   ## Test Plan
+   <test plan as markdown checklist>
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)
+   EOF
+   )"
+   ```
+
+5. Return the PR URL to the user.

--- a/events/scripts/scripts.js
+++ b/events/scripts/scripts.js
@@ -205,7 +205,7 @@ const CONFIG = {
     enableGuestBotDetection: false,
     api_parameters: { check_token: { guest_allowed: true } },
     onTokenExpired: () => {
-      window.locaton.reload();
+      window.location.reload();
     },
   },
   signInContext: getSusiOptions(),

--- a/head.html
+++ b/head.html
@@ -7,7 +7,7 @@
   const isAllowedAgent = allowedAgents && allowedAgents.some((agent) => userAgentString.includes(agent.trim()));
 
   const ssrFlag = document.querySelector('meta[name="head-loaded"]');
-  const LOCALES = ['ae_ar', 'ae_en', 'africa', 'ar', 'at', 'au', 'be_en', 'be_fr', 'be_nl', 'bg', 'br', 'ca_fr', 'ca', 'ch_de', 'ch_fr', 'ch_it', 'cl', 'cn', 'co', 'cr', 'cy_en', 'cz', 'de', 'dk', 'ec', 'ee', 'eg_ar', 'eg_en', 'el', 'es', 'fi', 'fr', 'gr_el', 'gr_en', 'gt', 'hk_en', 'hk_zh', 'hu', 'id_en', 'id_id', 'ie', 'il_en', 'il_he', 'in_hi', 'in', 'it', 'jp', 'kr', 'kw_ar', 'kw_en', 'la', 'langstore', 'lt', 'lu_de', 'lu_en', 'lu_fr', 'lv', 'mena_ar', 'mena_en', 'mt', 'mx', 'my_en', 'my_ms', 'ng', 'nl', 'no', 'nz', 'pe', 'ph_en', 'ph_fil', 'pl', 'pr', 'pt', 'qa_ar', 'qa_en', 'ro', 'ru', 'sa_ar', 'sa_en', 'se', 'sg', 'si', 'sk', 'th_en', 'th_th', 'tr', 'tw', 'ua', 'uk', 'vn_en', 'vn_vi', 'za'];
+  const LOCALES = ['ae_ar', 'ae_en', 'africa', 'ar', 'at', 'au', 'be_en', 'be_fr', 'be_nl', 'bg', 'br', 'ca_fr', 'ca', 'ch_de', 'ch_fr', 'ch_it', 'cl', 'cn', 'co', 'cr', 'cy_en', 'cz', 'de', 'dk', 'ec', 'ee', 'eg_ar', 'eg_en', 'el', 'es', 'fi', 'fr', 'gr_el', 'gr_en', 'gt', 'hk_en', 'hk_zh', 'hu', 'id_en', 'id_id', 'ie', 'il_en', 'il_he', 'in_hi', 'in', 'it', 'jp', 'kr', 'kw_ar', 'kw_en', 'la', 'lt', 'lu_de', 'lu_en', 'lu_fr', 'lv', 'mena_ar', 'mena_en', 'mt', 'mx', 'my_en', 'my_ms', 'ng', 'nl', 'no', 'nz', 'pe', 'ph_en', 'ph_fil', 'pl', 'pr', 'pt', 'qa_ar', 'qa_en', 'ro', 'ru', 'sa_ar', 'sa_en', 'se', 'sg', 'si', 'sk', 'th_en', 'th_th', 'tr', 'tw', 'ua', 'uk', 'vn_en', 'vn_vi', 'za'];
 
   (() => {
     function buildLink(language, url) {
@@ -30,7 +30,14 @@
       }
       
       try {
-        const response = await fetch(`${origin}${sitemapPath}`);
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), 5000);
+        let response;
+        try {
+          response = await fetch(`${origin}${sitemapPath}`, { signal: controller.signal });
+        } finally {
+          clearTimeout(timeoutId);
+        }
         if (!response.ok) {
           console.warn('Failed to fetch sitemap:', response.status);
           return;
@@ -46,10 +53,10 @@
         
         const urlElements = xmlDoc.querySelectorAll('url');
         let currentUrlElement = null;
-   
-        const isLocalRoot = `${sitemapOrigin}/${localeMatch}/` === `${sitemapOrigin}${pathname}`;
+        const correctedPath = pathname.endsWith('.html') ? pathname : `${pathname}.html`;
+        const isLocalRoot = localeMatch && `${sitemapOrigin}/${localeMatch}/` === `${sitemapOrigin}${pathname}`;
         const rootPage = isLocalRoot ? `${sitemapOrigin}/${localeMatch}/` : `${sitemapOrigin}/`; 
-        const currentPageUrl = pathname !== '/' && pathname !== `/${localeMatch}/` ? `${sitemapOrigin}${pathname}` : `${rootPage}`;
+        const currentPageUrl = pathname !== '/' && pathname !== `/${localeMatch}/` ? `${sitemapOrigin}${correctedPath}` : `${rootPage}`;
 
         for (const urlElement of urlElements) {
           const loc = urlElement.querySelector('loc')?.textContent;


### PR DESCRIPTION
## Release T3.26-20

Production promotion: **`stage` → `main`** for the T3.26-20 train.

### Release notes

#### Site behavior
- **`head.html` — locale / hreflang:** Updated document language and hreflang handling. Removed langstore usage, added `AbortController` and tighter validation for more robust locale wiring (see #24 / hreflang-update branch).
- **`events/scripts/scripts.js`:** Fixed a typo in the window reload logic (MWPW-195082, #30).

#### Tooling
- **Claude Code:** Added `.claude/commands/open-pr.md` — command workflow for opening PRs (#32).

#### Integrations
- **Dev merge:** File path and reference updates aligned with `dev` (#31).

### Scope (diff vs `main`)
- 3 files changed: `head.html`, `events/scripts/scripts.js`, `.claude/commands/open-pr.md`

### Merged work included in this promotion
| PR | Summary |
|----|---------|
| #32 | Claude / code-root — open PR command |
| #31 | File locations and references (dev) |
| #30 | MWPW-195082 — window reload typo fix |
| #24 | Hreflang / `head.html` updates |

Made with [Cursor](https://cursor.com)